### PR TITLE
feat: add feature to use yarn instead of npm

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ const parser = new (require('argparse').ArgumentParser)({
 parser.addArgument(['--prerelease-suffix'], { defaultValue: '', help: 'Suffix string to apply to the version if it is a prerelease version' });
 parser.addArgument(['--pom-file'], { help: 'Location of the pom.xml file. Defaults to use ./pom.xml' });
 parser.addArgument(['--package-file'], { help: 'Location of the package.json file. Defaults to use ./package.json' });
+parser.addArgument(['--use-yarn'], { action: 'storeTrue', help: 'Use Yarn instead of NPM to update the version' });
 const args = parser.parseArgs();
 
-syncPomToPackage(args.pom_file || undefined, args.package_file || undefined, { prereleaseSuffix: args.prerelease_suffix });
+syncPomToPackage(args.pom_file || undefined, args.package_file || undefined, { prereleaseSuffix: args.prerelease_suffix, useYarn: args.use_yarn });

--- a/src/syncPomToPackage.js
+++ b/src/syncPomToPackage.js
@@ -15,8 +15,8 @@ module.exports = (pomFile = './pom.xml', packageFile = './package.json', options
 
     return new Promise((resolve, reject) => {
         spawn(
-            'npm',
-            ['version', packageJson.version, '--force', '--no-git-tag-version', '--allow-same-version'],
+            options.useYarn ? 'yarn' : 'npm',
+            [options.useYarn ? 'version --new-version' : 'version', packageJson.version, '--force', '--no-git-tag-version', '--allow-same-version'],
             { cwd: path.dirname(packageFile), stdio: 'inherit', shell : true }
         ).on('exit', code => {
             code ? reject(code) : resolve();

--- a/test/syncPomToPackage.test.js
+++ b/test/syncPomToPackage.test.js
@@ -60,4 +60,9 @@ describe('syncPomToPackage', () => {
             expect(require(PACKAGE_FILE).version).to.equal('0.0.1-SNAPSHOT');
         });
     });
+    it('should use yarn', () => {
+        return syncPomToPackage(POM_FILE, PACKAGE_FILE, { useYarn: true }).then(() => {
+            expect(require(PACKAGE_FILE).version).to.equal('0.0.1-SNAPSHOT');
+        });
+    });
 });


### PR DESCRIPTION
In our project we had the problem that we only had a yarn binary. This PR should now provide the possibility to choose between yarn and npm to execute script.